### PR TITLE
Remove forward slash if host provide on URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 build
 *.log
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (server, opts) {
 
         if (opts.hostname) {
             baseUrl = req.connection.encrypted ? 'https://' : 'http://';
-            baseUrl += req.headers.host;
+            baseUrl += req.headers.host.replace(/\/$/, '') + '/';
         }
 
         // Copy the params object

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "mocha": "^2.2.5",
     "request-promise": "^0.4.3",
     "restify": "^4.0.0",
-    "should": "^7.0.4"
+    "should": "^13.2.1"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,6 +5,10 @@ var restify = require('restify'),
     server;
 
 describe('Paginate module with default options', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 3333;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -19,16 +23,17 @@ describe('Paginate module with default options', function () {
             res.send("OK");
         });
 
-        server.listen(3333, done);
+        server.listen(basePort, done);
 
     });
 
     it('should add the link header with the right last and next links', function (done) {
         request({
-            uri: 'http://localhost:3333/test',
+            baseUrl: baseUri,
+            uri: '/test',
             resolveWithFullResponse: true
         }).then(function (res) {
-            res.headers.link.should.be.eql('<http://localhost:3333/test?page=7>; rel="last", <http://localhost:3333/test?page=2>; rel="next"');
+            res.headers.link.should.be.eql(`<${baseUri}/test?page=7>; rel="last", <${baseUri}/test?page=2>; rel="next"`);
             done();
         }, function (err) {
             console.log(err);
@@ -37,10 +42,11 @@ describe('Paginate module with default options', function () {
     });
     it('should add the link header with the right last, next, prev and first links', function (done) {
         request({
-            uri: 'http://localhost:3333/test?page=4',
+            baseUrl: baseUri,
+            uri: '/test?page=4',
             resolveWithFullResponse: true
         }).then(function (res) {
-            res.headers.link.should.be.eql('<http://localhost:3333/test?page=1>; rel="first", <http://localhost:3333/test?page=3>; rel="prev", <http://localhost:3333/test?page=7>; rel="last", <http://localhost:3333/test?page=5>; rel="next"');
+            res.headers.link.should.be.eql(`<${baseUri}/test?page=1>; rel="first", <${baseUri}/test?page=3>; rel="prev", <${baseUri}/test?page=7>; rel="last", <${baseUri}/test?page=5>; rel="next"`);
             done();
         }, function (err) {
             console.log(err);
@@ -50,6 +56,9 @@ describe('Paginate module with default options', function () {
 });
 
 describe('Paginate module without hostnames', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 7777;
+    const baseUri = `${baseUrl}:${basePort}`;
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -66,13 +75,14 @@ describe('Paginate module without hostnames', function () {
             res.send("OK");
         });
 
-        server.listen(7777, done);
+        server.listen(basePort, done);
 
     });
 
     it('should add the link header with the right last and next links', function (done) {
         request({
-            uri: 'http://localhost:7777/test',
+            baseUrl: baseUri,
+            uri: '/test',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql('</test?page=7>; rel="last", </test?page=2>; rel="next"');
@@ -87,6 +97,10 @@ describe('Paginate module without hostnames', function () {
 describe('The paginate object added to the request object', function (done) {
     var testServer;
 
+    const baseUrl = 'http://localhost';
+    const basePort = 9999;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
         testServer = restify.createServer({
             name: 'test'
@@ -96,7 +110,7 @@ describe('The paginate object added to the request object', function (done) {
 
         testServer.use(paginate(testServer));
 
-        testServer.listen(9999, done);
+        testServer.listen(basePort, done);
     });
 
     it('should contain a page and per_page object', function (done) {
@@ -112,7 +126,8 @@ describe('The paginate object added to the request object', function (done) {
         });
 
         request({
-            uri: 'http://localhost:9999/object-test'
+            baseUrl: baseUri,
+            uri: '/object-test'
         });
     });
 
@@ -129,7 +144,8 @@ describe('The paginate object added to the request object', function (done) {
         });
 
         request({
-            uri: 'http://localhost:9999/type-test?page=2&per_page=2'
+            baseUrl: baseUri,
+            uri: '/type-test?page=2&per_page=2'
         });
     });
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -7,7 +7,7 @@ var restify = require('restify'),
 describe('Paginate module with default options', function () {
     const baseUrl = 'http://localhost';
     const basePort = 3333;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         server = restify.createServer({
@@ -30,7 +30,7 @@ describe('Paginate module with default options', function () {
     it('should add the link header with the right last and next links', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test',
+            uri: 'test',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql(`<${baseUri}/test?page=7>; rel="last", <${baseUri}/test?page=2>; rel="next"`);
@@ -43,7 +43,7 @@ describe('Paginate module with default options', function () {
     it('should add the link header with the right last, next, prev and first links', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=4',
+            uri: 'test?page=4',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql(`<${baseUri}/test?page=1>; rel="first", <${baseUri}/test?page=3>; rel="prev", <${baseUri}/test?page=7>; rel="last", <${baseUri}/test?page=5>; rel="next"`);
@@ -58,7 +58,7 @@ describe('Paginate module with default options', function () {
 describe('Paginate module without hostnames', function () {
     const baseUrl = 'http://localhost';
     const basePort = 7777;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -82,7 +82,7 @@ describe('Paginate module without hostnames', function () {
     it('should add the link header with the right last and next links', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test',
+            uri: 'test',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql('</test?page=7>; rel="last", </test?page=2>; rel="next"');
@@ -99,7 +99,7 @@ describe('The paginate object added to the request object', function (done) {
 
     const baseUrl = 'http://localhost';
     const basePort = 9999;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         testServer = restify.createServer({
@@ -127,7 +127,7 @@ describe('The paginate object added to the request object', function (done) {
 
         request({
             baseUrl: baseUri,
-            uri: '/object-test'
+            uri: 'object-test'
         });
     });
 
@@ -145,7 +145,7 @@ describe('The paginate object added to the request object', function (done) {
 
         request({
             baseUrl: baseUri,
-            uri: '/type-test?page=2&per_page=2'
+            uri: 'type-test?page=2&per_page=2'
         });
     });
 });

--- a/test/envelope.js
+++ b/test/envelope.js
@@ -5,6 +5,9 @@ var restify = require('restify'),
     server;
 
 describe('Paginate module with number only', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 4444;
+    const baseUri = `${baseUrl}:${basePort}`;
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -24,13 +27,14 @@ describe('Paginate module with number only', function () {
             });
         });
 
-        server.listen(4444, done);
+        server.listen(basePort, done);
 
     });
 
     it('should add to the response the `pages` key', function (done) {
         request({
-            uri: 'http://localhost:4444/test',
+            baseUrl: baseUri,
+            uri: '/test',
             json: true
         }).then(function (res) {
             should.exist(res.pages);
@@ -44,7 +48,8 @@ describe('Paginate module with number only', function () {
     });
     it('should add to the response the `pages` key and should contain the first and prev keys', function (done) {
         request({
-            uri: 'http://localhost:4444/test?page=2',
+            baseUrl: baseUri,
+            uri: '/test?page=2',
             json: true
         }).then(function (res) {
             should.exist(res.pages);

--- a/test/envelope.js
+++ b/test/envelope.js
@@ -7,7 +7,7 @@ var restify = require('restify'),
 describe('Paginate module with number only', function () {
     const baseUrl = 'http://localhost';
     const basePort = 4444;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -34,7 +34,7 @@ describe('Paginate module with number only', function () {
     it('should add to the response the `pages` key', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test',
+            uri: 'test',
             json: true
         }).then(function (res) {
             should.exist(res.pages);
@@ -49,7 +49,7 @@ describe('Paginate module with number only', function () {
     it('should add to the response the `pages` key and should contain the first and prev keys', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=2',
+            uri: 'test?page=2',
             json: true
         }).then(function (res) {
             should.exist(res.pages);

--- a/test/get-links.js
+++ b/test/get-links.js
@@ -6,6 +6,10 @@ var restify = require('restify'),
     server;
 
 describe('The getLinks() function', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 8888;
+    const baseUri = `${baseUrl}:${basePort}/`;
+
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -17,7 +21,7 @@ describe('The getLinks() function', function () {
 
         server.get('/test', function (req, res, next) {
             res.send({
-            	pages: res.paginate.getLinks(10)
+                pages: res.paginate.getLinks(10)
             });
         });
         server.get('/test-no-count', function (req, res, next) {
@@ -26,18 +30,29 @@ describe('The getLinks() function', function () {
             });
         });
 
-        server.listen(8888, done);
+        server.listen(basePort, done);
     });
 
-    it('should generate a prev, next, first and last page link, if count is provided', function(done) {
+    it('should generate a prev, next, first and last page link, if count is provided', function (done) {
         request({
-            uri: 'http://localhost:8888/test?page=3&per_page=2',
+            baseUrl: baseUri,
+            uri: 'test?page=3&per_page=2',
             json: true
         }).then(function (res) {
-            url.parse(res.pages.prev, true).query.should.have.property('page', '2');
-            url.parse(res.pages.next, true).query.should.have.property('page', '4');
-            url.parse(res.pages.first, true).query.should.have.property('page', '1');
-            url.parse(res.pages.last, true).query.should.have.property('page', '5');
+            should.exist(res.pages);
+
+            const prevUrl = Object.assign({}, url.parse(res.pages.prev, true).query);
+            prevUrl.should.have.property('page', '2');
+
+            const nextUrl = Object.assign({}, url.parse(res.pages.next, true).query);
+            nextUrl.should.have.property('page', '4');
+
+            const firstUrl = Object.assign({}, url.parse(res.pages.first, true).query);
+            firstUrl.should.have.property('page', '1');
+
+            const lastUrl = Object.assign({}, url.parse(res.pages.last, true).query);
+            lastUrl.should.have.property('page', '5');
+
             done();
         }, function (err) {
             console.log(err);
@@ -45,14 +60,21 @@ describe('The getLinks() function', function () {
         });
     });
 
-    it('should generate a prev, next and first (but not last) page link, if count isn\'t provided', function(done) {
+    it('should generate a prev, next and first (but not last) page link, if count isn\'t provided', function (done) {
         request({
-            uri: 'http://localhost:8888/test-no-count?testparam=test&page=3&per_page=2',
+            baseUrl: baseUri,
+            uri: 'test-no-count?testparam=test&page=3&per_page=2',
             json: true
         }).then(function (res) {
-            url.parse(res.pages.prev, true).query.should.have.property('page', '2');
-            url.parse(res.pages.next, true).query.should.have.property('page', '4');
-            url.parse(res.pages.first, true).query.should.have.property('page', '1');
+            const prevUrl = Object.assign({}, url.parse(res.pages.prev, true).query);
+            prevUrl.should.have.property('page', '2');
+
+            const nextUrl = Object.assign({}, url.parse(res.pages.next, true).query);
+            nextUrl.should.have.property('page', '4');
+
+            const firstUrl = Object.assign({}, url.parse(res.pages.first, true).query);
+            firstUrl.should.have.property('page', '1');
+
             res.pages.should.not.have.property('last');
             done();
         }, function (err) {
@@ -61,12 +83,13 @@ describe('The getLinks() function', function () {
         });
     });
 
-    it('should add the params of the initial request to the generated links, except for page', function(done) {
-    	request({
-            uri: 'http://localhost:8888/test?testparam=test&page=2&per_page=2',
+    it('should add the params of the initial request to the generated links, except for page', function (done) {
+        request({
+            baseUrl: baseUri,
+            uri: 'test?testparam=test&page=2&per_page=2',
             json: true
         }).then(function (res) {
-            var nextLinkParams = url.parse(res.pages.next, true).query;
+            var nextLinkParams = Object.assign({}, url.parse(res.pages.next, true).query);
             nextLinkParams.should.have.property('testparam', 'test');
             nextLinkParams.should.have.property('per_page', '2');
             nextLinkParams.should.not.have.property('page', '2');
@@ -77,16 +100,17 @@ describe('The getLinks() function', function () {
         });
     });
 
-    it('shouldn\'t return an empty last page, in case count % per_page === 0', function(done) {
+    it('shouldn\'t return an empty last page, in case count % per_page === 0', function (done) {
         request({
-            uri: 'http://localhost:8888/test?page=2&per_page=2',
+            baseUrl: baseUri,
+            uri: 'test?page=2&per_page=2',
             json: true
         }).then(function (res) {
-            var lastLinkParams = url.parse(res.pages.last, true).query;
+            var lastLinkParams = Object.assign({}, url.parse(res.pages.last, true).query);
 
             // the count is 10 and per_page is 2, therefore the last page should be 5
             lastLinkParams.should.have.property('page', '5');
-            
+
             done();
         }, function (err) {
             console.log(err);

--- a/test/options.js
+++ b/test/options.js
@@ -7,7 +7,7 @@ var restify = require('restify'),
 describe('Paginate module with `page` key overridden', function () {
     const baseUrl = 'http://localhost';
     const basePort = 5555;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         server = restify.createServer({
@@ -34,7 +34,7 @@ describe('Paginate module with `page` key overridden', function () {
     it('should add to the response the `pages` key', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test',
+            uri: 'test',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql(`<${baseUri}/test?page=6>; rel="last", <${baseUri}/test?page=1>; rel="next"`);
@@ -49,7 +49,7 @@ describe('Paginate module with `page` key overridden', function () {
 describe('Paginate module with `per_page` key overridden', function () {
     const baseUrl = 'http://localhost';
     const basePort = 6666;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         server = restify.createServer({
@@ -76,7 +76,7 @@ describe('Paginate module with `per_page` key overridden', function () {
     it('should add to the response the `pages` key', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test',
+            uri: 'test',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql(`<${baseUri}/test?page=16>; rel="last", <${baseUri}/test?page=2>; rel="next"`);
@@ -90,7 +90,7 @@ describe('Paginate module with `per_page` key overridden', function () {
     it('should add the per_page from the original url', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?per_page=30',
+            uri: 'test?per_page=30',
             resolveWithFullResponse: true
         }).then(function (res) {
             res.headers.link.should.be.eql(`<${baseUri}/test?per_page=30&page=11>; rel="last", <${baseUri}/test?per_page=30&page=2>; rel="next"`);

--- a/test/options.js
+++ b/test/options.js
@@ -5,6 +5,10 @@ var restify = require('restify'),
     server;
 
 describe('Paginate module with `page` key overridden', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 5555;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -23,16 +27,17 @@ describe('Paginate module with `page` key overridden', function () {
             res.send("OK");
         });
 
-        server.listen(5555, done);
+        server.listen(basePort, done);
 
     });
 
     it('should add to the response the `pages` key', function (done) {
         request({
-            uri: 'http://localhost:5555/test',
+            baseUrl: baseUri,
+            uri: '/test',
             resolveWithFullResponse: true
         }).then(function (res) {
-            res.headers.link.should.be.eql('<http://localhost:5555/test?page=6>; rel="last", <http://localhost:5555/test?page=1>; rel="next"');
+            res.headers.link.should.be.eql(`<${baseUri}/test?page=6>; rel="last", <${baseUri}/test?page=1>; rel="next"`);
             done();
         }, function (err) {
             console.log(err);
@@ -42,6 +47,10 @@ describe('Paginate module with `page` key overridden', function () {
 });
 
 describe('Paginate module with `per_page` key overridden', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 6666;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
         server = restify.createServer({
             name: 'test'
@@ -60,16 +69,17 @@ describe('Paginate module with `per_page` key overridden', function () {
             res.send("OK");
         });
 
-        server.listen(6666, done);
+        server.listen(basePort, done);
 
     });
 
     it('should add to the response the `pages` key', function (done) {
         request({
-            uri: 'http://localhost:6666/test',
+            baseUrl: baseUri,
+            uri: '/test',
             resolveWithFullResponse: true
         }).then(function (res) {
-            res.headers.link.should.be.eql('<http://localhost:6666/test?page=16>; rel="last", <http://localhost:6666/test?page=2>; rel="next"');
+            res.headers.link.should.be.eql(`<${baseUri}/test?page=16>; rel="last", <${baseUri}/test?page=2>; rel="next"`);
             done();
         }, function (err) {
             console.log(err);
@@ -79,10 +89,11 @@ describe('Paginate module with `per_page` key overridden', function () {
 
     it('should add the per_page from the original url', function (done) {
         request({
-            uri: 'http://localhost:6666/test?per_page=30',
+            baseUrl: baseUri,
+            uri: '/test?per_page=30',
             resolveWithFullResponse: true
         }).then(function (res) {
-            res.headers.link.should.be.eql('<http://localhost:6666/test?per_page=30&page=11>; rel="last", <http://localhost:6666/test?per_page=30&page=2>; rel="next"');
+            res.headers.link.should.be.eql(`<${baseUri}/test?per_page=30&page=11>; rel="last", <${baseUri}/test?per_page=30&page=2>; rel="next"`);
             done();
         }, function (err) {
             console.log(err);

--- a/test/paginated-response.js
+++ b/test/paginated-response.js
@@ -9,7 +9,7 @@ var restify = require('restify'),
 describe('The getPaginatedResponse() function', function () {
     const baseUrl = 'http://localhost';
     const basePort = 3434;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         for (var i = 0; i < 100; i++) {
@@ -35,7 +35,7 @@ describe('The getPaginatedResponse() function', function () {
     it('should return the paginated data', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=5&per_page=2',
+            uri: 'test?page=5&per_page=2',
             json: true
         }).then(function (res) {
             res.data.should.be.eql(testData.slice(8, 10));
@@ -49,7 +49,7 @@ describe('The getPaginatedResponse() function', function () {
     it('should return the pages', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=5&per_page=2',
+            uri: 'test?page=5&per_page=2',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');
@@ -66,7 +66,7 @@ describe('The getPaginatedResponse() function', function () {
     it('should return status 404 in case the page is out of range', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=500&per_page=10',
+            uri: 'test?page=500&per_page=10',
             json: true
         }).then(function (res) {
             var error = 'did not return 404!';
@@ -82,7 +82,7 @@ describe('The getPaginatedResponse() function', function () {
 describe('The getResponse() function', function () {
     const baseUrl = 'http://localhost';
     const basePort = 4343;
-    const baseUri = `${baseUrl}:${basePort}`;
+    const baseUri = `${baseUrl}:${basePort}/`;
 
     before(function (done) {
         for (var i = 0; i < 5; i++) {
@@ -111,7 +111,7 @@ describe('The getResponse() function', function () {
     it('should return the data', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=5&per_page=5',
+            uri: 'test?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.data.should.be.eql(testData);
@@ -125,7 +125,7 @@ describe('The getResponse() function', function () {
     it('should return the pages', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test?page=5&per_page=5',
+            uri: 'test?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');
@@ -142,7 +142,7 @@ describe('The getResponse() function', function () {
     it('should not return the last page, if count hasn\'t been provided', function (done) {
         request({
             baseUrl: baseUri,
-            uri: '/test-no-count?page=5&per_page=5',
+            uri: 'test-no-count?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');

--- a/test/paginated-response.js
+++ b/test/paginated-response.js
@@ -7,8 +7,12 @@ var restify = require('restify'),
     server;
 
 describe('The getPaginatedResponse() function', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 3434;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
-        for(var i = 0; i < 100; i++) {
+        for (var i = 0; i < 100; i++) {
             // generate random string
             testData[i] = Math.random().toString(36).substring(8);
         }
@@ -25,12 +29,13 @@ describe('The getPaginatedResponse() function', function () {
             res.paginate.sendPaginated(testData);
         });
 
-        server.listen(3434, done);
+        server.listen(basePort, done);
     });
 
-    it('should return the paginated data', function(done) {
+    it('should return the paginated data', function (done) {
         request({
-            uri: 'http://localhost:3434/test?page=5&per_page=2',
+            baseUrl: baseUri,
+            uri: '/test?page=5&per_page=2',
             json: true
         }).then(function (res) {
             res.data.should.be.eql(testData.slice(8, 10));
@@ -41,9 +46,10 @@ describe('The getPaginatedResponse() function', function () {
         });
     });
 
-    it('should return the pages', function(done) {
+    it('should return the pages', function (done) {
         request({
-            uri: 'http://localhost:3434/test?page=5&per_page=2',
+            baseUrl: baseUri,
+            uri: '/test?page=5&per_page=2',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');
@@ -57,9 +63,10 @@ describe('The getPaginatedResponse() function', function () {
         });
     });
 
-    it('should return status 404 in case the page is out of range', function(done) {
+    it('should return status 404 in case the page is out of range', function (done) {
         request({
-            uri: 'http://localhost:3434/test?page=500&per_page=10',
+            baseUrl: baseUri,
+            uri: '/test?page=500&per_page=10',
             json: true
         }).then(function (res) {
             var error = 'did not return 404!';
@@ -73,8 +80,12 @@ describe('The getPaginatedResponse() function', function () {
 });
 
 describe('The getResponse() function', function () {
+    const baseUrl = 'http://localhost';
+    const basePort = 4343;
+    const baseUri = `${baseUrl}:${basePort}`;
+
     before(function (done) {
-        for(var i = 0; i < 5; i++) {
+        for (var i = 0; i < 5; i++) {
             // generate random string
             testData[i] = Math.random().toString(36).substring(8);
         }
@@ -97,9 +108,10 @@ describe('The getResponse() function', function () {
         server.listen(4343, done);
     });
 
-    it('should return the data', function(done) {
+    it('should return the data', function (done) {
         request({
-            uri: 'http://localhost:4343/test?page=5&per_page=5',
+            baseUrl: baseUri,
+            uri: '/test?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.data.should.be.eql(testData);
@@ -110,9 +122,10 @@ describe('The getResponse() function', function () {
         });
     });
 
-    it('should return the pages', function(done) {
+    it('should return the pages', function (done) {
         request({
-            uri: 'http://localhost:4343/test?page=5&per_page=5',
+            baseUrl: baseUri,
+            uri: '/test?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');
@@ -126,9 +139,10 @@ describe('The getResponse() function', function () {
         });
     });
 
-    it('should not return the last page, if count hasn\'t been provided', function(done) {
+    it('should not return the last page, if count hasn\'t been provided', function (done) {
         request({
-            uri: 'http://localhost:4343/test-no-count?page=5&per_page=5',
+            baseUrl: baseUri,
+            uri: '/test-no-count?page=5&per_page=5',
             json: true
         }).then(function (res) {
             res.pages.should.have.property('prev');


### PR DESCRIPTION
I don't know why my server is not providing the last forward slash, so when I generate the links for the pagination this is the result I get `http://localhost:8080api/resource/...`.

With this pull request I used RegExp to remove the last forward slash if host provided. Then add the last forward slash. So now when I generate the links I get `http://localhost:8080/api/resource/...`